### PR TITLE
Refactor Winning Player

### DIFF
--- a/pong-sdl/pong-sdl/ball.c
+++ b/pong-sdl/pong-sdl/ball.c
@@ -228,8 +228,8 @@ isCollidedWithPlayerChangeCourse(Ball* ball, Player* player, int32_t nextBallPix
 bool
 isCollidedWithPlayerY(size_t ballY, Player* player) {
   Pixel* playerPixel = getPlayerTopPixel(player);
-  size_t startY = getPixelY(playerPixel);
-  size_t endY = startY + getPlayerHeight(player);
+  int32_t startY = getPixelY(playerPixel);
+  int32_t endY = startY + getPlayerHeight(player);
 
   if (ballY < startY) {
     return false;
@@ -251,9 +251,9 @@ changeBallMovement(Ball* ball, Player* player, size_t x, size_t y) {
   /* static double_t pi = acos(-1); */
 
   // Get degrees
-  size_t playerLengthY = getPlayerHeight(player);
+  int32_t playerLengthY = getPlayerHeight(player);
   Pixel* playerTopPixel = getPlayerTopPixel(player);
-  size_t playerTopPixelY = getPixelY(playerTopPixel);
+  int32_t playerTopPixelY = getPixelY(playerTopPixel);
 
   size_t midPointY = playerTopPixelY + (playerLengthY / 2);
 
@@ -329,8 +329,8 @@ isCollidedWithBorder(Ball* ball, Border* border) {
 
 void
 isCollidedWithBorderChangeCourse(Ball* ball, Border* border, int32_t nextBallPixelX, int32_t nextBallPixelY) {
-  int32_t ballPixelX = (int32_t)getPixelX(ball->pixel);
-  int32_t ballPixelY = (int32_t)getPixelY(ball->pixel);
+  int32_t ballPixelX = getPixelX(ball->pixel);
+  int32_t ballPixelY = getPixelY(ball->pixel);
 
   int32_t newBallX = nextBallPixelX;
   int32_t newBallY = nextBallPixelY;
@@ -350,8 +350,8 @@ isCollidedWithBorderChangeCourse(Ball* ball, Border* border, int32_t nextBallPix
 
 void
 moveBall(Ball* ball, Player* leftPlayer, Player* rightPlayer, Border* topBorder, Border* bottomBorder) {
-  int32_t ballPixelX = (int32_t)getPixelX(ball->pixel);
-  int32_t ballPixelY = (int32_t)getPixelY(ball->pixel);
+  int32_t ballPixelX = getPixelX(ball->pixel);
+  int32_t ballPixelY = getPixelY(ball->pixel);
 
   int32_t nextBallPixelX = ballPixelX + ball->ballMovement.x;
   int32_t nextBallPixelY = ballPixelY + ball->ballMovement.y;
@@ -399,10 +399,10 @@ stopBall(Ball* ball) {
 
 enum EPlayerSide
 isBallOutOfBounds(Ball* ball, Player* leftPlayer, Player* rightPlayer) {
-  size_t ballX = getPixelX(ball->pixel);
+  int32_t ballX = getPixelX(ball->pixel);
 
   Pixel* leftPlayerPixel = getPlayerTopPixel(leftPlayer);
-  size_t leftPlayerX = getPixelX(leftPlayerPixel);
+  int32_t leftPlayerX = getPixelX(leftPlayerPixel);
 
   if (ballX <= LEFT_BORDER) {
     incrementPlayerScore(rightPlayer);
@@ -411,7 +411,7 @@ isBallOutOfBounds(Ball* ball, Player* leftPlayer, Player* rightPlayer) {
   }
 
   Pixel* rightPlayerPixel = getPlayerTopPixel(rightPlayer);
-  size_t rightPlayerX = getPixelX(rightPlayerPixel);
+  int32_t rightPlayerX = getPixelX(rightPlayerPixel);
   if (ballX >= RIGHT_BORDER) {
     incrementPlayerScore(leftPlayer);
 

--- a/pong-sdl/pong-sdl/ball.c
+++ b/pong-sdl/pong-sdl/ball.c
@@ -418,7 +418,7 @@ isBallOutOfBounds(Ball* ball, Player* leftPlayer, Player* rightPlayer) {
     return LEFT_SIDE;
   }
 
-  return 0;
+  return NO_WINNING_SIDE;
 }
 
 Pixel*

--- a/pong-sdl/pong-sdl/main.c
+++ b/pong-sdl/pong-sdl/main.c
@@ -101,7 +101,7 @@ SDL_AppEvent(void* appstate, SDL_Event* event) {
   }
 
   EGameMode mode = getGameMode(screen);
-  if (mode == GameInProgressNoWin || mode == GameInProgress) {
+  if (mode == GameInProgress) {
     SDL_Keycode key = event->key.key;
     Player* leftPlayer = getLeftPlayer(screen);
     Player* rightPlayer = getRightPlayer(screen);
@@ -184,6 +184,8 @@ renderPlayerScore(Player* player, size_t x, size_t y) {
         printf("Failed to read score of Right Player\n");
         exit(EXIT_FAILURE);
       }
+      break;
+    default:
       break;
   }
 
@@ -306,7 +308,7 @@ renderGameMode(Screen* screen) {
 
       break;
     case GameLost:
-      winningSide = getLastPlayerToWin(screen);
+      winningSide = getWinnerOfPreviousRound(screen);
       switch (winningSide) {
         case LEFT_SIDE:
           SDL_RenderDebugText(renderer, x, y, "Left Player wins the round!");
@@ -315,6 +317,8 @@ renderGameMode(Screen* screen) {
         case RIGHT_SIDE:
           SDL_RenderDebugText(renderer, x, y, "Right Player wins the round!");
 
+          break;
+        default:
           break;
       }
 
@@ -333,8 +337,6 @@ renderGameMode(Screen* screen) {
 
       SDL_RenderDebugText(renderer, x, y + TEXT_AREA_HEIGHT * 5, "Press P to un(P)ause");
       break;
-    case GameInProgressNoWin:
-      /* FALLTHROUGH */
     case GameInProgress:
       SDL_RenderDebugText(renderer, x, y, "Playing");
 
@@ -361,7 +363,7 @@ SDL_AppIterate(void* appstate) {
 
   const float scale = pixelScale;
   SDL_SetRenderScale(renderer, scale, scale);
-  if (mode == GameInProgressNoWin || mode == GameInProgress) {
+  if (mode == GameInProgress) {
     Player* leftPlayer = getLeftPlayer(screen);
     Player* rightPlayer = getRightPlayer(screen);
 
@@ -382,7 +384,8 @@ SDL_AppIterate(void* appstate) {
     }
   }
 
-  bool isGameLost = (mode == GameLost) || isLost(screen);
+  // If game is lost then do not check again if a player has lost
+  bool isGameLost = mode == GameLost || isLost(screen);
   if (isGameLost) {
     setGameToLost(screen);
   }
@@ -404,7 +407,7 @@ SDL_AppIterate(void* appstate) {
 
   SDL_RenderPresent(renderer);
 
-  if ((mode == GameInProgressNoWin || mode == GameInProgress) && isScreenRerendered) {
+  if (mode == GameInProgress && isScreenRerendered) {
     moveScreenBall(screen);
   }
 

--- a/pong-sdl/pong-sdl/main.c
+++ b/pong-sdl/pong-sdl/main.c
@@ -273,8 +273,8 @@ renderBall(Ball* ball) {
 void
 renderPlayer(Player* player) {
   Pixel* pixel = getPlayerTopPixel(player);
-  size_t x = getPixelX(pixel);
-  size_t y = getPixelY(pixel);
+  int32_t x = getPixelX(pixel);
+  int32_t y = getPixelY(pixel);
 
   SDL_FRect playerFrect;
 

--- a/pong-sdl/pong-sdl/pixel.c
+++ b/pong-sdl/pong-sdl/pixel.c
@@ -1,32 +1,33 @@
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "./pixel.h"
 
 struct _pixel {
   // TODO: change to uint32_t
-  size_t x;
-  size_t y;
+  int32_t x;
+  int32_t y;
 
   enum EBlockTypes type;
 };
 
 void
-setPixelX(Pixel* pixel, size_t x) {
+setPixelX(Pixel* pixel, int32_t x) {
   pixel->x = x;
 }
 
 void
-setPixelY(Pixel* pixel, size_t y) {
+setPixelY(Pixel* pixel, int32_t y) {
   pixel->y = y;
 }
 
-size_t
+int32_t
 getPixelX(Pixel* pixel) {
   return pixel->x;
 }
 
-size_t
+int32_t
 getPixelY(Pixel* pixel) {
   return pixel->y;
 }

--- a/pong-sdl/pong-sdl/pixel.h
+++ b/pong-sdl/pong-sdl/pixel.h
@@ -2,6 +2,7 @@
 #define __PONG_SDL_PIXEL__
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include "./constants.h"
@@ -10,10 +11,10 @@ enum EBlockTypes { BACKGROUND_BLOCK = 0b0, NET_BLOCK = 0b1, PLAYER_BLOCK = 0b10,
 
 typedef struct _pixel Pixel;
 
-void setPixelX(Pixel*, size_t);
-void setPixelY(Pixel*, size_t);
-size_t getPixelX(Pixel*);
-size_t getPixelY(Pixel*);
+void setPixelX(Pixel*, int32_t);
+void setPixelY(Pixel*, int32_t);
+int32_t getPixelX(Pixel*);
+int32_t getPixelY(Pixel*);
 
 Pixel* initPixel(size_t x, size_t y, enum EBlockTypes blockType);
 void destroyPixel(Pixel* pixel);

--- a/pong-sdl/pong-sdl/player.c
+++ b/pong-sdl/pong-sdl/player.c
@@ -29,9 +29,9 @@ getPlayerTopPixel(Player* player) {
   return player->top;
 }
 
-size_t
+int32_t
 getPlayerLengthMidPointY(Player* player) {
-  size_t y = getPixelY(player->top);
+  int32_t y = getPixelY(player->top);
 
   return y + (player->height / 2) - 1;
 }
@@ -79,7 +79,7 @@ destroyPlayer(Player* player) {
 
 bool
 movePlayerUp(Player* player) {
-  size_t topY = getPixelY(player->top);
+  int32_t topY = getPixelY(player->top);
   if (topY <= (TOP_BORDER + PLAYER_BLOCK_HEIGHT)) {
     return false;
   }
@@ -99,7 +99,7 @@ setPlayerMovement(Player* player, enum EPlayerMovement newMovement) {
 
 bool
 movePlayerDown(Player* player) {
-  size_t topY = getPixelY(player->top);
+  int32_t topY = getPixelY(player->top);
   if ((topY + player->height) >= BOTTOM_BORDER) {
     return false;
   }

--- a/pong-sdl/pong-sdl/player.h
+++ b/pong-sdl/pong-sdl/player.h
@@ -19,7 +19,7 @@ void incrementPlayerScore(Player*);
 size_t getPlayerScore(Player*);
 enum EPlayerSide getPlayerSide(Player*);
 Pixel* getPlayerTopPixel(Player*);
-size_t getPlayerLengthMidPointY(Player*);
+int32_t getPlayerLengthMidPointY(Player*);
 int32_t getPlayerWidth(Player*);
 int32_t getPlayerHeight(Player*);
 bool movePlayerUp(Player*);

--- a/pong-sdl/pong-sdl/player.h
+++ b/pong-sdl/pong-sdl/player.h
@@ -8,7 +8,7 @@
 
 enum EPlayerMovement { NO_MOVEMENT, DOWN_MOVEMENT, UP_MOVEMENT };
 
-enum EPlayerSide { LEFT_SIDE = 1, RIGHT_SIDE };
+enum EPlayerSide { NO_WINNING_SIDE = 0, LEFT_SIDE, RIGHT_SIDE };
 
 typedef struct _player Player;
 

--- a/pong-sdl/pong-sdl/screen.h
+++ b/pong-sdl/pong-sdl/screen.h
@@ -4,12 +4,14 @@
 #include "./ball.h"
 #include "./player.h"
 
-enum EGameMode { GameNotStated, GameInProgressNoWin, GameInProgress, GamePaused, GameLost, GameQuit, GameRestart };
+enum EGameMode { GameNotStated, GameInProgress, GamePaused, GameLost, GameQuit, GameRestart };
 typedef enum EGameMode EGameMode;
 
 typedef struct _screen Screen;
 
-enum EPlayerSide getLastPlayerToWin(Screen*);
+enum EPlayerSide getWinner(Screen*);
+enum EPlayerSide getWinnerOfPreviousRound(Screen*);
+
 void continueGame(Screen*);
 bool isLost(Screen*);
 void moveScreenBall(Screen*);


### PR DESCRIPTION
[Refactor Winning Player]()

## Description

1. Bug Fix: Game thought that the **Left Player** won -- instead of losing --  because there was an _unsigned_ minus operation (i.e., `ballX - leftPlayerX` overflowed to a larger number, instead of to a negative). This was solved by changing the type to the `signed int32_t`.
2. Remove the **GameInProgressNoWin** game mode.